### PR TITLE
Fix configuration and env checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
-    "dev": "tsx src/index.ts",
+    "start": "node dist/api/handler.js",
+    "dev": "tsx src/api/handler.ts",
     "mcp": "tsx src/mcp/server.ts",
     "api": "tsx src/api/handler.ts"
   },

--- a/src/notion/createSimpleNote.ts
+++ b/src/notion/createSimpleNote.ts
@@ -5,7 +5,11 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const notion = new Client({ auth: process.env.NOTION_API_TOKEN });
-const TEST_PAGE_ID = process.env.NOTION_TEST_PAGE_ID!;
+const TEST_PAGE_ID = process.env.NOTION_TEST_PAGE_ID;
+
+if (!TEST_PAGE_ID) {
+  throw new Error("NOTION_TEST_PAGE_ID environment variable is not set");
+}
 
 export async function createSimpleNote(title: string, content: string): Promise<string> {
   const now = new Date().toISOString();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- correct npm scripts to run the actual API entrypoint
- ensure NOTION_TEST_PAGE_ID must exist when creating a note
- include Node type definitions in tsconfig

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_683fa08ed210832db8808efae2ff4449