### PR TITLE
Add configurable API URL for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Notion MCP Server
+
+This repository contains a small server and Expo frontend. The frontend uses a configurable API base URL so that requests can be directed to different backends.
+
+## Configuring the API URL
+
+The file `frontend/constants/api.ts` exports `API_BASE_URL`. It reads the value from the environment variable `EXPO_PUBLIC_API_BASE_URL` and falls back to `http://localhost:3001` if the variable is not set.
+
+```
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:3001';
+```
+
+### Development
+
+Create a `.env` file (or use your preferred method) and set `EXPO_PUBLIC_API_BASE_URL` to the address of your local server:
+
+```
+EXPO_PUBLIC_API_BASE_URL=http://localhost:3001
+```
+
+### Production
+
+Set `EXPO_PUBLIC_API_BASE_URL` to your production API URL when building or deploying the Expo app:
+
+```
+EXPO_PUBLIC_API_BASE_URL=https://api.example.com
+```
+
+The app will use this URL when performing fetch requests.

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { StyleSheet, TextInput, Button, Alert } from 'react-native';
 import { View, Text } from '@/components/Themed';
+import { API_BASE_URL } from '@/constants/api';
 
 export default function IndexScreen() {
   const [message, setMessage] = useState('');
@@ -15,7 +16,7 @@ export default function IndexScreen() {
     setLoading(true);
 
     try {
-      const res = await fetch('http://localhost:3001/create-note', {
+      const res = await fetch(`${API_BASE_URL}/create-note`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/constants/api.ts
+++ b/frontend/constants/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:3001';


### PR DESCRIPTION
## Summary
- allow configuration of API base URL via `EXPO_PUBLIC_API_BASE_URL`
- update Index screen to use the new constant
- document overriding the API URL for dev and prod

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d8a74020832d81932dfabdb5ffc7