### PR TITLE
Add .env example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Notion API integration token
+NOTION_API_TOKEN=your-notion-api-token
+
+# Page ID used for testing note creation
+NOTION_TEST_PAGE_ID=your-test-page-id
+
+# Optional port for the API server
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Notion MCP Server
+
+This project contains a small server that exposes Model Context Protocol tools backed by the Notion API.
+
+## Setup
+
+1. Install dependencies for the server:
+   ```bash
+   cd server
+   npm install
+   ```
+2. Copy `.env.example` to `server/.env` and fill in the required values.
+   ```bash
+   cp ../.env.example .env
+   ```
+   - `NOTION_API_TOKEN` – your Notion integration token.
+   - `NOTION_TEST_PAGE_ID` – ID of the page used for note creation.
+   - `PORT` – optional port for the Express API.
+
+## Running the server
+
+From the `server` directory run:
+```bash
+npm run mcp
+```


### PR DESCRIPTION
## Summary
- document environment setup in README
- provide a `.env.example` with placeholder variables

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in `server` *(fails: tsconfig has no inputs)*

------
https://chatgpt.com/codex/tasks/task_e_6840d8a58f94832dbd5c0f4665214031