### PR TITLE
Make server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Notion MCP Server
+
+This repository contains a simple Express API that interacts with a Model Context Protocol (MCP) server and the Notion API.
+
+## Environment Variables
+
+Configuration is provided via a `.env` file located in the `server` directory. Copy `server/.env.example` to `server/.env` and fill in the required values.
+
+| Variable | Description |
+| -------- | ----------- |
+| `PORT` | Port used by the API server (defaults to `3001`). |
+| `NOTION_API_TOKEN` | Notion integration token for API access. |
+| `NOTION_TEST_PAGE_ID` | Page ID where test notes will be created. |
+
+## Running the Server
+
+Install dependencies and start the API in development mode:
+
+```bash
+cd server
+npm install
+npm run dev
+```
+
+The server will start on the port defined by `PORT` or `3001` by default.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables for the server
+# HTTP server port. Defaults to 3001 if not set.
+PORT=3001
+
+# Notion API token used by the MCP server
+NOTION_API_TOKEN=
+
+# Target page ID for creating notes during testing
+NOTION_TEST_PAGE_ID=

--- a/server/src/api/handler.ts
+++ b/server/src/api/handler.ts
@@ -2,9 +2,12 @@
 import express, { Request, Response } from "express";
 import { spawn } from "child_process";
 import cors from "cors"; // 추가
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const app = express();
-const port = 3001;
+const port = parseInt(process.env.PORT || "3001", 10);
 
 // CORS 허용 설정 추가
 app.use(cors({


### PR DESCRIPTION
## Summary
- allow configuring API server port using `PORT` env var
- document environment variables and server usage
- provide `.env.example` with default settings

## Testing
- `npm run build` *(fails: No inputs were found in config file)*


------
https://chatgpt.com/codex/tasks/task_e_6840d8a41fc8832da22bb1914adcfe2c