### PR TITLE
Fix tsconfig include path

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,6 +14,6 @@
     "sourceMap": true,
     "types": ["node"]
   },
-  "include": ["/src/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- update server/tsconfig.json so that included files use a relative path

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6840d89ae070832da420b4318ed7616c